### PR TITLE
Fixes #61. ustring.IsNullOrEmpty doesn't work the same way as the string.IsNullOrEmpty method.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 [*.cs]
 indent_style = tab
-indent_size = 8
-tab_width = 8
+indent_size = 4
+tab_width = 4
 csharp_new_line_before_open_brace = methods,local_functions
 csharp_new_line_before_else = false
 csharp_new_line_before_catch = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,23 @@
 [*.cs]
 indent_style = tab
+indent_size = 8
+tab_width = 8
+csharp_new_line_before_open_brace = methods,local_functions
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+end_of_line = crlf
+
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = false
+csharp_indent_labels = flush_left
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_preserve_single_line_blocks = true
+dotnet_style_require_accessibility_modifiers = never
+csharp_style_var_when_type_is_apparent = true
+csharp_prefer_braces = false
+csharp_space_before_open_square_brackets = true
+csharp_space_between_method_call_name_and_opening_parenthesis = true
+csharp_space_between_method_declaration_name_and_open_parenthesis = true

--- a/NStack.sln
+++ b/NStack.sln
@@ -8,6 +8,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NStackTests", "NStackTests\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution Files", "{760C271D-E55A-4F44-BE2C-9B476D310CAC}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\publish.yml = .github\workflows\publish.yml
 		README.md = README.md

--- a/NStack/strings/ustring.cs
+++ b/NStack/strings/ustring.cs
@@ -155,8 +155,7 @@ namespace NStack {
 					if (size == 0)
 						size = 1;
 					this.block = Marshal.AllocHGlobal (size);
-					unsafe
-					{
+					unsafe {
 						Buffer.MemoryCopy ((void*)block, (void*)this.block, size, size);
 					}
 				} else {
@@ -182,8 +181,7 @@ namespace NStack {
 					throw new ArgumentException (nameof (count));
 				if (fromOffset + count > size)
 					throw new ArgumentException (nameof (count));
-				unsafe
-				{
+				unsafe {
 					byte* p = ((byte*)block) + fromOffset;
 
 					for (int i = 0; i < count; i++, p++)
@@ -193,16 +191,14 @@ namespace NStack {
 
 			public override string ToString ()
 			{
-				unsafe
-				{
+				unsafe {
 					return Encoding.UTF8.GetString ((byte*)block, size);
 				}
 			}
 
 			protected internal override ustring GetRange (int start, int end)
 			{
-				unsafe
-				{
+				unsafe {
 					return new IntPtrSubUString (this, (IntPtr)((byte*)block + start), size: end - start);
 				}
 			}
@@ -210,8 +206,7 @@ namespace NStack {
 			internal override int RealIndexByte (byte b, int offset)
 			{
 				var t = size - offset;
-				unsafe
-				{
+				unsafe {
 					byte* p = (byte*)block + offset;
 					for (int i = 0; i < t; i++) {
 						if (p [i] == b)
@@ -307,8 +302,7 @@ namespace NStack {
 			internal override int RealIndexByte (byte b, int offset)
 			{
 				var t = Length - offset;
-				unsafe
-				{
+				unsafe {
 					fixed (byte* p = &buffer [offset]) {
 						for (int i = 0; i < t; i++)
 							if (p [i] == b)
@@ -376,8 +370,7 @@ namespace NStack {
 			internal override int RealIndexByte (byte b, int offset)
 			{
 				var t = count - offset;
-				unsafe
-				{
+				unsafe {
 					fixed (byte* p = &buffer [start + offset]) {
 						for (int i = 0; i < t; i++)
 							if (p [i] == b)
@@ -429,7 +422,7 @@ namespace NStack {
 		/// <param name="rune">Rune (short name for Unicode code point).</param>
 		public static ustring Make (Rune rune)
 		{
-			return new ByteBufferUString ((uint) rune);
+			return new ByteBufferUString ((uint)rune);
 		}
 
 		/// <summary>
@@ -630,8 +623,7 @@ namespace NStack {
 		static bool EqualsHelper (ustring a, ustring b)
 		{
 			// If both string are identical, return true.
-			if (a.SequenceEqual(b))
-			{
+			if (a.SequenceEqual (b)) {
 				return true;
 			}
 
@@ -644,8 +636,7 @@ namespace NStack {
 			var abs = a as ByteBufferUString;
 			var bbs = b as ByteBufferUString;
 			if ((object)abs != null && (object)bbs != null) {
-				unsafe
-				{
+				unsafe {
 					fixed (byte* ap = &abs.buffer [0]) fixed (byte* bp = &bbs.buffer [0]) {
 						return EqualsHelper (ap, bp, alen);
 					}
@@ -654,8 +645,7 @@ namespace NStack {
 			var aip = a as IntPtrUString;
 			var bip = b as IntPtrUString;
 			if ((object)aip != null && (object)bip != null) {
-				unsafe
-				{
+				unsafe {
 					return EqualsHelper ((byte*)aip.block, (byte*)bip.block, alen);
 				}
 			}
@@ -719,6 +709,9 @@ namespace NStack {
 		/// </remarks>
 		public static implicit operator ustring (string str)
 		{
+			if (str == null)
+				return null;
+
 			return new ByteBufferUString (str);
 		}
 
@@ -946,7 +939,7 @@ namespace NStack {
 				int size = Length;
 				if (end < 0)
 					end = size + end;
-				
+
 				if (start < 0)
 					start = size + start;
 
@@ -1042,11 +1035,10 @@ namespace NStack {
 			if (runeStart < 0)
 				runeStart = 0;
 
-			var runes = this.ToRunes();
+			var runes = this.ToRunes ();
 			ustring usRange = "";
-			for (int i = runeStart; i < runeStart + length; i++)
-			{
-				usRange += ustring.Make(runes [i]);
+			for (int i = runeStart; i < runeStart + length; i++) {
+				usRange += ustring.Make (runes [i]);
 			}
 			return usRange;
 		}
@@ -1073,7 +1065,7 @@ namespace NStack {
 				for (int i = 0; i < blen;) {
 					(var rune, var size) = Utf8.DecodeRune (this, i, i - blen);
 					i += size;
-					total += Rune.ColumnWidth(rune);
+					total += Rune.ColumnWidth (rune);
 				}
 				return total;
 			}
@@ -1261,7 +1253,7 @@ namespace NStack {
 		/// <param name="substr">Substr.</param>
 		public int Count (ustring substr)
 		{
-			if ((object) substr == null)
+			if ((object)substr == null)
 				throw new ArgumentNullException (nameof (substr));
 			int n = 0;
 			if (substr.Length == 0)
@@ -1349,7 +1341,7 @@ namespace NStack {
 		{
 			if ((object)substr == null)
 				throw new ArgumentNullException (nameof (substr));
-			
+
 			var n = substr.Length;
 			if (n == 0)
 				return offset;
@@ -1388,7 +1380,7 @@ namespace NStack {
 
 			if (h == hashss && CompareStringRange (this, offset, n, substr))
 				return offset;
-			
+
 			for (int i = n; i < blen;) {
 				var reali = offset + i;
 				h *= primeRK;
@@ -1419,7 +1411,7 @@ namespace NStack {
 			if (n == 1)
 				return LastIndexByte (substr [0]);
 			if (n == Length) {
-				if (((object)substr == (object) this))
+				if (((object)substr == (object)this))
 					return 0;
 
 				if (CompareStringRange (substr, 0, n, this))
@@ -1521,7 +1513,7 @@ namespace NStack {
 
 			for (int i = 0; i < blen;) {
 				(var rune, var size) = Utf8.DecodeRune (this, i, i - blen);
-				for (int j = 0; j < clen; ) {
+				for (int j = 0; j < clen;) {
 					(var crune, var csize) = Utf8.DecodeRune (chars, j, j - clen);
 					if (crune == rune)
 						return i;
@@ -1583,7 +1575,7 @@ namespace NStack {
 				if (AsciiSet.MakeAsciiSet (ref aset, chars)) {
 					for (int i = blen - 1; i >= 0; i--)
 						if (AsciiSet.Contains (ref aset, this [i]))
-					    		return i;
+							return i;
 					return -1;
 				}
 			}
@@ -1665,7 +1657,7 @@ namespace NStack {
 				var m = IndexOf (sep, offset);
 				if (m < 0)
 					break;
-				result [i] = this [offset, m+sepSave];
+				result [i] = this [offset, m + sepSave];
 				offset = m + sepLen;
 				i++;
 			}
@@ -1698,7 +1690,7 @@ namespace NStack {
 				throw new ArgumentNullException (nameof (prefix));
 			if (Length < prefix.Length)
 				return false;
-			return CompareStringRange (this, 0, prefix.Length, prefix);	
+			return CompareStringRange (this, 0, prefix.Length, prefix);
 		}
 
 		/// <summary>
@@ -1763,15 +1755,13 @@ namespace NStack {
 		// most-significant bit of the highest word, map to the full range of all
 		// 128 ASCII characters. The 128-bits of the upper 16 bytes will be zeroed,
 		// ensuring that any non-ASCII character will be reported as not in the set.
-		struct AsciiSet
-		{
+		struct AsciiSet {
 			unsafe internal fixed uint ascii [8];
 
 			public static bool MakeAsciiSet (ref AsciiSet aset, ustring chars)
 			{
 				var n = chars.Length;
-				unsafe
-				{
+				unsafe {
 					fixed (uint* ascii = aset.ascii) {
 						for (int i = 0; i < n; i++) {
 							var c = chars [i];
@@ -1789,8 +1779,7 @@ namespace NStack {
 			public static bool MakeAsciiSet (ref AsciiSet aset, uint [] runes)
 			{
 				var n = runes.Length;
-				unsafe
-				{
+				unsafe {
 					fixed (uint* ascii = aset.ascii) {
 						for (int i = 0; i < n; i++) {
 							var r = runes [i];
@@ -1806,8 +1795,7 @@ namespace NStack {
 			}
 			public static bool Contains (ref AsciiSet aset, byte b)
 			{
-				unsafe
-				{
+				unsafe {
 					fixed (uint* ascii = aset.ascii) {
 						return (ascii [b >> 5] & (1 << (b & 31))) != 0;
 					}
@@ -1831,6 +1819,19 @@ namespace NStack {
 			if (u2 != null)
 				u2.CopyTo (fromOffset: 0, target: copy, targetOffset: u1l, count: u2l);
 			return new ByteBufferUString (copy);
+		}
+
+		/// <summary>
+		/// Convert from <see cref="string"/> to <see cref="ustring"/>
+		/// or to null if the <paramref name="v"/> is null.
+		/// </summary>
+		/// <param name="v">The ustring.</param>
+		public static explicit operator string (ustring v)
+		{
+			if (v == null)
+				return null;
+
+			return v.ToString ();
 		}
 
 		/// <summary>
@@ -1927,7 +1928,7 @@ namespace NStack {
 				var mapped = mapping (rune);
 
 				// common case
-				if (0 < mapped && mapped <= Utf8.RuneSelf){
+				if (0 < mapped && mapped <= Utf8.RuneSelf) {
 					result [targetOffset] = (byte)mapped;
 					targetOffset++;
 					continue;
@@ -2165,7 +2166,7 @@ namespace NStack {
 		int FlexLastIndexOf (RunePredicate matchFunc, bool expected)
 		{
 			int blen = Length;
-			for (int i = blen; i > 0; ){
+			for (int i = blen; i > 0;) {
 				(var rune, var size) = Utf8.DecodeLastRune (this, i);
 				i -= size;
 				if (matchFunc (rune) == expected)
@@ -2206,8 +2207,8 @@ namespace NStack {
 						(_, var wid) = Utf8.DecodeRune (this, start);
 						j += wid;
 					}
-				} else 
-					j += IndexOf (oldValue, start)-start;
+				} else
+					j += IndexOf (oldValue, start) - start;
 				var copyCount = j - start;
 				if (copyCount > 0) {
 					CopyTo (fromOffset: start, target: result, targetOffset: w, count: copyCount);
@@ -2304,7 +2305,7 @@ namespace NStack {
 		object IConvertible.ToType (Type conversionType, IFormatProvider provider)
 		{
 			if (conversionType == typeof (string))
-			    return ToString ();
+				return ToString ();
 			return Convert.ChangeType (ToString (), conversionType);
 		}
 

--- a/NStackTests/NStackTests.csproj
+++ b/NStackTests/NStackTests.csproj
@@ -10,8 +10,8 @@
     <Version>0.20.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/NStackTests/ustringTest.cs
+++ b/NStackTests/ustringTest.cs
@@ -274,8 +274,8 @@ namespace NStackTests {
 			("abc", "XYZ", false),
 			("abcdefghijk", "abcdefghijX", false),
 
-					// need byte array for these, as they are not 
-					("abcdefghijk", "abcdefghij\u212A", true),
+			// need byte array for these, as they are not 
+			("abcdefghijk", "abcdefghij\u212A", true),
 			("abcdefghijK", "abcdefghij\u212A", true),
 			("abcdefghijkz", "abcdefghij\u212Ay", false),
 			("abcdefghijKz", "abcdefghij\u212Ay", false),
@@ -591,7 +591,7 @@ namespace NStackTests {
 			("foo", "o", 2),
 			("abcABCabc", "A", 3),
 			("abcABCabc", "a", 6),
-	    };
+		};
 
 		[Test]
 		public void TestLastIndex ()
@@ -771,11 +771,23 @@ namespace NStackTests {
 		[Test]
 		public void Substring_Same_As_String_Substring ()
 		{
-			ustring text = "Check this out 你";
-			var str = text.ToString ();
-			str = str?.Substring (0, Math.Min (17, str.Length));
-			var ustr = text.Substring (0, text.Length);
+			ustring ustrText = "Check this out 你";
+			string str = (string)ustrText.Substring (0, ustrText.Length);
+			Assert.AreEqual (16, str.Length);
+			ustring ustr = ustrText.Substring (0, ustrText.Length);
+			Assert.AreEqual (18, ustr.Length);
 			Assert.AreEqual (str, ustr);
+			Assert.AreEqual (str, ustrText);
+			Assert.AreEqual (ustr, ustrText);
+
+			string strText = "Check this out 你";
+			str = strText.Substring (0, strText.Length);
+			Assert.AreEqual (16, str.Length);
+			ustr = strText.Substring (0, strText.Length);
+			Assert.AreEqual (18, ustr.Length);
+			Assert.AreEqual (str, ustr);
+			Assert.AreEqual (str, strText);
+			Assert.AreEqual (ustr, strText);
 		}
 
 		[Test]

--- a/NStackTests/ustringTest.cs
+++ b/NStackTests/ustringTest.cs
@@ -138,67 +138,66 @@ namespace NStackTests {
 
 		// string, substring, expected
 		(string, string, bool) [] ContainTests = {
-	("abc", "bc", true),
-	("abc", "bcd", false),
-	("abc", "", true),
-	("", "a", false),
-
+			("abc", "bc", true),
+			("abc", "bcd", false),
+			("abc", "", true),
+			("", "a", false),
 			// 2-byte needle
 			("xxxxxx", "01", false),
-	("01xxxx", "01", true),
-	("xx01xx", "01", true),
-	("xxxx01", "01", true),
-	("1xxxxx", "01", false),
-	("xxxxx0", "01", false),
+			("01xxxx", "01", true),
+			("xx01xx", "01", true),
+			("xxxx01", "01", true),
+			("1xxxxx", "01", false),
+			("xxxxx0", "01", false),
 			// 3-byte needle
 			("xxxxxxx", "012", false),
-	("012xxxx", "012", true),
-	("xx012xx", "012", true),
-	("xxxx012", "012", true),
-	("12xxxxx", "012", false),
-	("xxxxx01", "012", false),
+			("012xxxx", "012", true),
+			("xx012xx", "012", true),
+			("xxxx012", "012", true),
+			("12xxxxx", "012", false),
+			("xxxxx01", "012", false),
 			// 4-byte needle
 			("xxxxxxxx", "0123", false),
-	("0123xxxx", "0123", true),
-	("xx0123xx", "0123", true),
-	("xxxx0123", "0123", true),
-	("123xxxxx", "0123", false),
-	("xxxxx012", "0123", false),
+			("0123xxxx", "0123", true),
+			("xx0123xx", "0123", true),
+			("xxxx0123", "0123", true),
+			("123xxxxx", "0123", false),
+			("xxxxx012", "0123", false),
 			// 5-7-byte needle
 			("xxxxxxxxx", "01234", false),
-	("01234xxxx", "01234", true),
-	("xx01234xx", "01234", true),
-	("xxxx01234", "01234", true),
-	("1234xxxxx", "01234", false),
-	("xxxxx0123", "01234", false),
+			("01234xxxx", "01234", true),
+			("xx01234xx", "01234", true),
+			("xxxx01234", "01234", true),
+			("1234xxxxx", "01234", false),
+			("xxxxx0123", "01234", false),
 			// 8-byte needle
 			("xxxxxxxxxxxx", "01234567", false),
-	("01234567xxxx", "01234567", true),
-	("xx01234567xx", "01234567", true),
-	("xxxx01234567", "01234567", true),
-	("1234567xxxxx", "01234567", false),
-	("xxxxx0123456", "01234567", false),
+			("01234567xxxx", "01234567", true),
+			("xx01234567xx", "01234567", true),
+			("xxxx01234567", "01234567", true),
+			("1234567xxxxx", "01234567", false),
+			("xxxxx0123456", "01234567", false),
 			// 9-15-byte needle
 			("xxxxxxxxxxxxx", "012345678", false),
-	("012345678xxxx", "012345678", true),
-	("xx012345678xx", "012345678", true),
-	("xxxx012345678", "012345678", true),
-	("12345678xxxxx", "012345678", false),
-	("xxxxx01234567", "012345678", false),
+			("012345678xxxx", "012345678", true),
+			("xx012345678xx", "012345678", true),
+			("xxxx012345678", "012345678", true),
+			("12345678xxxxx", "012345678", false),
+			("xxxxx01234567", "012345678", false),
 			// 16-byte needle
 			("xxxxxxxxxxxxxxxxxxxx", "0123456789ABCDEF", false),
-	("0123456789ABCDEFxxxx", "0123456789ABCDEF", true),
-	("xx0123456789ABCDEFxx", "0123456789ABCDEF", true),
-	("xxxx0123456789ABCDEF", "0123456789ABCDEF", true),
-	("123456789ABCDEFxxxxx", "0123456789ABCDEF", false),
-	("xxxxx0123456789ABCDE", "0123456789ABCDEF", false),
+			("0123456789ABCDEFxxxx", "0123456789ABCDEF", true),
+			("xx0123456789ABCDEFxx", "0123456789ABCDEF", true),
+			("xxxx0123456789ABCDEF", "0123456789ABCDEF", true),
+			("123456789ABCDEFxxxxx", "0123456789ABCDEF", false),
+			("xxxxx0123456789ABCDE", "0123456789ABCDEF", false),
 			// 17-31-byte needle
 			("xxxxxxxxxxxxxxxxxxxxx", "0123456789ABCDEFG", false),
-	("0123456789ABCDEFGxxxx", "0123456789ABCDEFG", true),
-	("xx0123456789ABCDEFGxx", "0123456789ABCDEFG", true),
-	("xxxx0123456789ABCDEFG", "0123456789ABCDEFG", true),
-	("123456789ABCDEFGxxxxx", "0123456789ABCDEFG", false),
-	("xxxxx0123456789ABCDEF", "0123456789ABCDEFG", false),
+			("0123456789ABCDEFGxxxx", "0123456789ABCDEFG", true),
+			("xx0123456789ABCDEFGxx", "0123456789ABCDEFG", true),
+			("xxxx0123456789ABCDEFG", "0123456789ABCDEFG", true),
+			("123456789ABCDEFGxxxxx", "0123456789ABCDEFG", false),
+			("xxxxx0123456789ABCDEF", "0123456789ABCDEFG", false),
 
 			// partial match cases
 			("xx01x", "012", false),                             // 3
@@ -210,18 +209,18 @@ namespace NStackTests {
 		(string, string, bool) [] containsAnyTests = {
 			// string, substring, expected
 			("", "", false),
-	("", "a", false),
-	("", "abc", false),
-	("a", "", false),
-	("a", "a", true),
-	("aaa", "a", true),
-	("abc", "xyz", false),
-	("abc", "xcz", true),
-	("a☺b☻c☹d", "uvw☻xyz", true),
-	("aRegExp*", ".(|)*+?^$[]", true),
-	("1....2....3....41....2....3....41....2....3....4", " ", false),
+			("", "a", false),
+			("", "abc", false),
+			("a", "", false),
+			("a", "a", true),
+			("aaa", "a", true),
+			("abc", "xyz", false),
+			("abc", "xcz", true),
+			("a☺b☻c☹d", "uvw☻xyz", true),
+			("aRegExp*", ".(|)*+?^$[]", true),
+			("1....2....3....41....2....3....41....2....3....4", " ", false),
 
-    };
+		};
 
 		[Test]
 		public void TestContainsAny ()
@@ -247,15 +246,15 @@ namespace NStackTests {
 		}
 
 		(string, uint, bool) [] containsRuneTests = {
-	("", 'a', false),
-	("a", 'a', true),
-	("aaa", 'a', true),
-	("abc", 'y', false),
-	("abc", 'c', true),
-	("a☺b☻c☹d", 'x', false),
-	("a☺b☻c☹d", '☻', true),
-	("aRegExp*", '*', true),
-    };
+			("", 'a', false),
+			("a", 'a', true),
+			("aaa", 'a', true),
+			("abc", 'y', false),
+			("abc", 'c', true),
+			("a☺b☻c☹d", 'x', false),
+			("a☺b☻c☹d", '☻', true),
+			("aRegExp*", '*', true),
+		};
 
 		[Test]
 		public void TestContainsRune ()
@@ -267,21 +266,21 @@ namespace NStackTests {
 		}
 
 		(string, string, bool) [] equalFoldsTest = {
-	("abc", "abc", true),
-	("ABcd", "ABcd", true),
-	("123abc", "123ABC", true),
-	("αβδ", "ΑΒΔ", true),
-	("abc", "xyz", false),
-	("abc", "XYZ", false),
-	("abcdefghijk", "abcdefghijX", false),
+			("abc", "abc", true),
+			("ABcd", "ABcd", true),
+			("123abc", "123ABC", true),
+			("αβδ", "ΑΒΔ", true),
+			("abc", "xyz", false),
+			("abc", "XYZ", false),
+			("abcdefghijk", "abcdefghijX", false),
 
-			// need byte array for these, as they are not 
-			("abcdefghijk", "abcdefghij\u212A", true),
-	("abcdefghijK", "abcdefghij\u212A", true),
-	("abcdefghijkz", "abcdefghij\u212Ay", false),
-	("abcdefghijKz", "abcdefghij\u212Ay", false),
+					// need byte array for these, as they are not 
+					("abcdefghijk", "abcdefghij\u212A", true),
+			("abcdefghijK", "abcdefghij\u212A", true),
+			("abcdefghijkz", "abcdefghij\u212Ay", false),
+			("abcdefghijKz", "abcdefghij\u212Ay", false),
 
-    };
+		};
 
 		[Test]
 		public void TestEqualFolds ()
@@ -296,17 +295,17 @@ namespace NStackTests {
 		}
 
 		(string, string, int) [] countTests = {
-	("", "", 1),
-	("", "notempty", 0),
-	("notempty", "", 9),
-	("smaller", "not smaller", 0),
-	("12345678987654321", "6", 2),
-	("611161116", "6", 3),
-	("notequal", "NotEqual", 0),
-	("equal", "equal", 1),
-	("abc1231231123q", "123", 3),
-	("11111", "11", 2)
-    };
+			("", "", 1),
+			("", "notempty", 0),
+			("notempty", "", 9),
+			("smaller", "not smaller", 0),
+			("12345678987654321", "6", 2),
+			("611161116", "6", 3),
+			("notequal", "NotEqual", 0),
+			("equal", "equal", 1),
+			("abc1231231123q", "123", 3),
+			("11111", "11", 2)
+		};
 
 		[Test]
 		public void TestCount ()
@@ -461,25 +460,25 @@ namespace NStackTests {
 		static (string, string, string, int, string) [] replaceTexts = {
 			// input, oldValue, newValue, n parameter, expected
 			("hello", "l", "L", 0, "hello"),
-	("hello", "l", "L", -1, "heLLo"),
-	("hello", "x", "X", -1, "hello"),
-	("", "x", "X", -1, ""),
-	("radar", "r", "<r>", -1, "<r>ada<r>"),
-	("", "", "<>", -1, "<>"),
-	("banana", "a", "<>", -1, "b<>n<>n<>"),
-	("banana", "a", "<>", 1, "b<>nana"),
-	("banana", "a", "<>", 1000, "b<>n<>n<>"),
-	("banana", "an", "<>", -1, "b<><>a"),
-	("banana", "ana", "<>", -1, "b<>na"),
-	("banana", "", "<>", -1, "<>b<>a<>n<>a<>n<>a<>"),
-	("banana", "", "<>", 10, "<>b<>a<>n<>a<>n<>a<>"),
-	("banana", "", "<>", 6, "<>b<>a<>n<>a<>n<>a"),
-	("banana", "", "<>", 5, "<>b<>a<>n<>a<>na"),
-	("banana", "", "<>", 1, "<>banana"),
-	("banana", "a", "a", -1, "banana"),
-	("banana", "a", "a", 1, "banana"),
-	("☺☻☹", "", "<>", -1, "<>☺<>☻<>☹<>")
-    };
+			("hello", "l", "L", -1, "heLLo"),
+			("hello", "x", "X", -1, "hello"),
+			("", "x", "X", -1, ""),
+			("radar", "r", "<r>", -1, "<r>ada<r>"),
+			("", "", "<>", -1, "<>"),
+			("banana", "a", "<>", -1, "b<>n<>n<>"),
+			("banana", "a", "<>", 1, "b<>nana"),
+			("banana", "a", "<>", 1000, "b<>n<>n<>"),
+			("banana", "an", "<>", -1, "b<><>a"),
+			("banana", "ana", "<>", -1, "b<>na"),
+			("banana", "", "<>", -1, "<>b<>a<>n<>a<>n<>a<>"),
+			("banana", "", "<>", 10, "<>b<>a<>n<>a<>n<>a<>"),
+			("banana", "", "<>", 6, "<>b<>a<>n<>a<>n<>a"),
+			("banana", "", "<>", 5, "<>b<>a<>n<>a<>na"),
+			("banana", "", "<>", 1, "<>banana"),
+			("banana", "a", "a", -1, "banana"),
+			("banana", "a", "a", 1, "banana"),
+			("☺☻☹", "", "<>", -1, "<>☺<>☻<>☹<>")
+		};
 
 		[Test]
 		public void TestReplace ()
@@ -495,80 +494,80 @@ namespace NStackTests {
 		(string, string, int) [] indexTests = {
 			// string, substring, expected index return
 			("", "", 0),
-	("", "a", -1),
-	("", "foo", -1),
-	("fo", "foo", -1),
-	("foo", "foo", 0),
-	("oofofoofooo", "f", 2),
-	("oofofoofooo", "foo", 4),
-	("barfoobarfoo", "foo", 3),
-	("foo", "", 0),
-	("foo", "o", 1),
-	("abcABCabc", "A", 3),
+			("", "a", -1),
+			("", "foo", -1),
+			("fo", "foo", -1),
+			("foo", "foo", 0),
+			("oofofoofooo", "f", 2),
+			("oofofoofooo", "foo", 4),
+			("barfoobarfoo", "foo", 3),
+			("foo", "", 0),
+			("foo", "o", 1),
+			("abcABCabc", "A", 3),
 			// cases with one byte strings - test special case in Index()
 			("", "a", -1),
-	("x", "a", -1),
-	("x", "x", 0),
-	("abc", "a", 0),
-	("abc", "b", 1),
-	("abc", "c", 2),
-	("abc", "x", -1),
+			("x", "a", -1),
+			("x", "x", 0),
+			("abc", "a", 0),
+			("abc", "b", 1),
+			("abc", "c", 2),
+			("abc", "x", -1),
 			// test special cases in Index() for short strings
 			("", "ab", -1),
-	("bc", "ab", -1),
-	("ab", "ab", 0),
-	("xab", "ab", 1),
-	("", "abc", -1),
-	("xbc", "abc", -1),
-	("abc", "abc", 0),
-	("xabc", "abc", 1),
-	("xabxc", "abc", -1),
-	("", "abcd", -1),
-	("xbcd", "abcd", -1),
-	("abcd", "abcd", 0),
-	("xabcd", "abcd", 1),
-	("xbcqq", "abcqq", -1),
-	("abcqq", "abcqq", 0),
-	("xabcqq", "abcqq", 1),
-	("xabxcqq", "abcqq", -1),
-	("xabcqxq", "abcqq", -1),
-	("", "01234567", -1),
-	("32145678", "01234567", -1),
-	("01234567", "01234567", 0),
-	("x01234567", "01234567", 1),
-	("x0123456x01234567", "01234567", 9),
-	("", "0123456789", -1),
-	("3214567844", "0123456789", -1),
-	("0123456789", "0123456789", 0),
-	("x0123456789", "0123456789", 1),
-	("x012345678x0123456789", "0123456789", 11),
-	("x01234567x89", "0123456789", -1),
-	("", "0123456789012345", -1),
-	("3214567889012345", "0123456789012345", -1),
-	("0123456789012345", "0123456789012345", 0),
-	("x0123456789012345", "0123456789012345", 1),
-	("x012345678901234x0123456789012345", "0123456789012345", 17),
-	("", "01234567890123456789", -1),
-	("32145678890123456789", "01234567890123456789", -1),
-	("01234567890123456789", "01234567890123456789", 0),
-	("x01234567890123456789", "01234567890123456789", 1),
-	("x0123456789012345678x01234567890123456789", "01234567890123456789", 21),
-	("", "0123456789012345678901234567890", -1),
-	("321456788901234567890123456789012345678911", "0123456789012345678901234567890", -1),
-	("0123456789012345678901234567890", "0123456789012345678901234567890", 0),
-	("x0123456789012345678901234567890", "0123456789012345678901234567890", 1),
-	("x012345678901234567890123456789x0123456789012345678901234567890", "0123456789012345678901234567890", 32),
-	("", "01234567890123456789012345678901", -1),
-	("32145678890123456789012345678901234567890211", "01234567890123456789012345678901", -1),
-	("01234567890123456789012345678901", "01234567890123456789012345678901", 0),
-	("x01234567890123456789012345678901", "01234567890123456789012345678901", 1),
-	("x0123456789012345678901234567890x01234567890123456789012345678901", "01234567890123456789012345678901", 33),
-	("xxxxxx012345678901234567890123456789012345678901234567890123456789012", "012345678901234567890123456789012345678901234567890123456789012", 6),
-	("", "0123456789012345678901234567890123456789", -1),
-	("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456789", 2),
-	("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456xxx", -1),
-	("xx0123456789012345678901234567890123456789012345678901234567890120123456789012345678901234567890123456xxx", "0123456789012345678901234567890123456xxx", 65)
-    };
+			("bc", "ab", -1),
+			("ab", "ab", 0),
+			("xab", "ab", 1),
+			("", "abc", -1),
+			("xbc", "abc", -1),
+			("abc", "abc", 0),
+			("xabc", "abc", 1),
+			("xabxc", "abc", -1),
+			("", "abcd", -1),
+			("xbcd", "abcd", -1),
+			("abcd", "abcd", 0),
+			("xabcd", "abcd", 1),
+			("xbcqq", "abcqq", -1),
+			("abcqq", "abcqq", 0),
+			("xabcqq", "abcqq", 1),
+			("xabxcqq", "abcqq", -1),
+			("xabcqxq", "abcqq", -1),
+			("", "01234567", -1),
+			("32145678", "01234567", -1),
+			("01234567", "01234567", 0),
+			("x01234567", "01234567", 1),
+			("x0123456x01234567", "01234567", 9),
+			("", "0123456789", -1),
+			("3214567844", "0123456789", -1),
+			("0123456789", "0123456789", 0),
+			("x0123456789", "0123456789", 1),
+			("x012345678x0123456789", "0123456789", 11),
+			("x01234567x89", "0123456789", -1),
+			("", "0123456789012345", -1),
+			("3214567889012345", "0123456789012345", -1),
+			("0123456789012345", "0123456789012345", 0),
+			("x0123456789012345", "0123456789012345", 1),
+			("x012345678901234x0123456789012345", "0123456789012345", 17),
+			("", "01234567890123456789", -1),
+			("32145678890123456789", "01234567890123456789", -1),
+			("01234567890123456789", "01234567890123456789", 0),
+			("x01234567890123456789", "01234567890123456789", 1),
+			("x0123456789012345678x01234567890123456789", "01234567890123456789", 21),
+			("", "0123456789012345678901234567890", -1),
+			("321456788901234567890123456789012345678911", "0123456789012345678901234567890", -1),
+			("0123456789012345678901234567890", "0123456789012345678901234567890", 0),
+			("x0123456789012345678901234567890", "0123456789012345678901234567890", 1),
+			("x012345678901234567890123456789x0123456789012345678901234567890", "0123456789012345678901234567890", 32),
+			("", "01234567890123456789012345678901", -1),
+			("32145678890123456789012345678901234567890211", "01234567890123456789012345678901", -1),
+			("01234567890123456789012345678901", "01234567890123456789012345678901", 0),
+			("x01234567890123456789012345678901", "01234567890123456789012345678901", 1),
+			("x0123456789012345678901234567890x01234567890123456789012345678901", "01234567890123456789012345678901", 33),
+			("xxxxxx012345678901234567890123456789012345678901234567890123456789012", "012345678901234567890123456789012345678901234567890123456789012", 6),
+			("", "0123456789012345678901234567890123456789", -1),
+			("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456789", 2),
+			("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456xxx", -1),
+			("xx0123456789012345678901234567890123456789012345678901234567890120123456789012345678901234567890123456xxx", "0123456789012345678901234567890123456xxx", 65)
+		};
 
 		[Test]
 		public void TestIndex ()
@@ -579,21 +578,20 @@ namespace NStackTests {
 		}
 
 		(string, string, int) [] lastIndexTests = {
-	("", "", 0),
-	("", "a", -1),
-	("", "foo", -1),
-	("fo", "foo", -1),
-	("foo", "foo", 0),
-	("foo", "f", 0),
-	("oofofoofooo", "f", 7),
-	("oofofoofooo", "foo", 7),
-	("barfoobarfoo", "foo", 9),
-	("foo", "", 3),
-	("foo", "o", 2),
-	("abcABCabc", "A", 3),
-	("abcABCabc", "a", 6),
-
-    };
+			("", "", 0),
+			("", "a", -1),
+			("", "foo", -1),
+			("fo", "foo", -1),
+			("foo", "foo", 0),
+			("foo", "f", 0),
+			("oofofoofooo", "f", 7),
+			("oofofoofooo", "foo", 7),
+			("barfoobarfoo", "foo", 9),
+			("foo", "", 3),
+			("foo", "o", 2),
+			("abcABCabc", "A", 3),
+			("abcABCabc", "a", 6),
+	    };
 
 		[Test]
 		public void TestLastIndex ()
@@ -604,45 +602,45 @@ namespace NStackTests {
 		}
 
 		(string, string, int) [] indexAnyTests = {
-	("", "", -1),
-	("", "a", -1),
-	("", "abc", -1),
-	("a", "", -1),
-	("a", "a", 0),
-	("aaa", "a", 0),
-	("abc", "xyz", -1),
-	("abc", "xcz", 2),
-	("ab☺c", "x☺yz", 2),
-	("a☺b☻c☹d", "cx", ustring.Make ("a☺b☻").Length),
-	("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
-	("aRegExp*", ".(|)*+?^$[]", 7),
-	("1....2....3....41....2....3....41....2....3....4", " ", -1),
+			("", "", -1),
+			("", "a", -1),
+			("", "abc", -1),
+			("a", "", -1),
+			("a", "a", 0),
+			("aaa", "a", 0),
+			("abc", "xyz", -1),
+			("abc", "xcz", 2),
+			("ab☺c", "x☺yz", 2),
+			("a☺b☻c☹d", "cx", ustring.Make ("a☺b☻").Length),
+			("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
+			("aRegExp*", ".(|)*+?^$[]", 7),
+			("1....2....3....41....2....3....41....2....3....4", " ", -1),
 
 			// Need a byte initializer instead for Go [\xff][b] below
 			// ("012abcba210", "\xffb", 4),
 			//("012\x80bcb\x80210", "\xffb", 3)			
 		}, lastIndexAnyTests = {
-	("abc", "xyz", -1),
-	("a", "a", 0),
-	("", "", -1),
-	("", "a", -1),
-	("", "abc", -1),
-	("a", "", -1),
-	("aaa", "a", 2),
-	("abc", "ab", 1),
-	("ab☺c", "x☺yz", 2),
-	("a☺b☻c☹d", "cx", ustring.Make("a☺b☻").Length),
-	("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
-	("a.RegExp*", ".(|)*+?^$[]", 8),
-	("1....2....3....41....2....3....41....2....3....4", " ", -1),
+			("abc", "xyz", -1),
+			("a", "a", 0),
+			("", "", -1),
+			("", "a", -1),
+			("", "abc", -1),
+			("a", "", -1),
+			("aaa", "a", 2),
+			("abc", "ab", 1),
+			("ab☺c", "x☺yz", 2),
+			("a☺b☻c☹d", "cx", ustring.Make("a☺b☻").Length),
+			("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
+			("a.RegExp*", ".(|)*+?^$[]", 8),
+			("1....2....3....41....2....3....41....2....3....4", " ", -1),
 			// Need a byte initializer instead for Go [\xff][b] below
 			//("012abcba210", "\xffb", 6),
 			//("012\x80bcb\x80210", "\xffb", 7)
 		}, lastIndexByteTests = {
-	("abcdefabcdef", "a", ustring.Make("abcdef").Length),      // something in the middle
+			("abcdefabcdef", "a", ustring.Make("abcdef").Length),      // something in the middle
 			("", "q", -1),
-	("abcdef", "q", -1),
-	("abcdefabcdef", "f", ustring.Make("abcdefabcde").Length), // last byte
+			("abcdef", "q", -1),
+			("abcdefabcdef", "f", ustring.Make("abcdefabcde").Length), // last byte
 			("zabcdefabcdef", "z", 0),                 // first byte
 			("a☺b☻c☹d", "b", ustring.Make("a☺").Length),               // non-ascii
 		};
@@ -675,17 +673,17 @@ namespace NStackTests {
 		public void TestIndexRune ()
 		{
 			(string, uint, int) [] testFirst = {
-	("", 'a', -1),
-	("", '☺', -1),
-	("foo", '☹', -1),
-	("foo", 'o', 1),
-	("foo☺bar", '☺', 3),
-	("foo☺☻☹bar", '☹', 9),
-	("a A x", 'A', 2),
-	("some_text=some_value", '=', 9),
-	("☺a", 'a', 3),
-	("a☻☺b", '☺', 4),
-	};
+				("", 'a', -1),
+				("", '☺', -1),
+				("foo", '☹', -1),
+				("foo", 'o', 1),
+				("foo☺bar", '☺', 3),
+				("foo☺☻☹bar", '☹', 9),
+				("a A x", 'A', 2),
+				("some_text=some_value", '=', 9),
+				("☺a", 'a', 3),
+				("a☻☺b", '☺', 4),
+			};
 			foreach ((string str, uint rune, int expected) in testFirst) {
 				var ustr = ustring.Make (str);
 				Assert.AreEqual (expected, ustr.IndexOf (rune));

--- a/NStackTests/ustringTest.cs
+++ b/NStackTests/ustringTest.cs
@@ -103,12 +103,12 @@ namespace NStackTests {
 			var cp = ustring.Make (c1, len);
 
 			var apalias = ap;
-			Assert.IsTrue(ap.Equals(bp));
+			Assert.IsTrue (ap.Equals (bp));
 			Assert.IsTrue (ap == bp);
 
 			string arefMod = "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdy$";
-			Assert.IsFalse(ap.Equals(arefMod));
-			Assert.IsFalse(ap == arefMod);
+			Assert.IsFalse (ap.Equals (arefMod));
+			Assert.IsFalse (ap == arefMod);
 
 			Assert.IsTrue (ap == apalias);
 			Assert.IsTrue (ap != cp);
@@ -138,67 +138,67 @@ namespace NStackTests {
 
 		// string, substring, expected
 		(string, string, bool) [] ContainTests = {
-			("abc", "bc", true),
-			("abc", "bcd", false),
-			("abc", "", true),
-			("", "a", false),
+	("abc", "bc", true),
+	("abc", "bcd", false),
+	("abc", "", true),
+	("", "a", false),
 
 			// 2-byte needle
 			("xxxxxx", "01", false),
-			("01xxxx", "01", true),
-			("xx01xx", "01", true),
-			("xxxx01", "01", true),
-			("1xxxxx", "01", false),
-			("xxxxx0", "01", false),
+	("01xxxx", "01", true),
+	("xx01xx", "01", true),
+	("xxxx01", "01", true),
+	("1xxxxx", "01", false),
+	("xxxxx0", "01", false),
 			// 3-byte needle
 			("xxxxxxx", "012", false),
-			("012xxxx", "012", true),
-			("xx012xx", "012", true),
-			("xxxx012", "012", true),
-			("12xxxxx", "012", false),
-			("xxxxx01", "012", false),
+	("012xxxx", "012", true),
+	("xx012xx", "012", true),
+	("xxxx012", "012", true),
+	("12xxxxx", "012", false),
+	("xxxxx01", "012", false),
 			// 4-byte needle
 			("xxxxxxxx", "0123", false),
-			("0123xxxx", "0123", true),
-			("xx0123xx", "0123", true),
-			("xxxx0123", "0123", true),
-			("123xxxxx", "0123", false),
-			("xxxxx012", "0123", false),
+	("0123xxxx", "0123", true),
+	("xx0123xx", "0123", true),
+	("xxxx0123", "0123", true),
+	("123xxxxx", "0123", false),
+	("xxxxx012", "0123", false),
 			// 5-7-byte needle
 			("xxxxxxxxx", "01234", false),
-			("01234xxxx", "01234", true),
-			("xx01234xx", "01234", true),
-			("xxxx01234", "01234", true),
-			("1234xxxxx", "01234", false),
-			("xxxxx0123", "01234", false),
+	("01234xxxx", "01234", true),
+	("xx01234xx", "01234", true),
+	("xxxx01234", "01234", true),
+	("1234xxxxx", "01234", false),
+	("xxxxx0123", "01234", false),
 			// 8-byte needle
 			("xxxxxxxxxxxx", "01234567", false),
-			("01234567xxxx", "01234567", true),
-			("xx01234567xx", "01234567", true),
-			("xxxx01234567", "01234567", true),
-			("1234567xxxxx", "01234567", false),
-			("xxxxx0123456", "01234567", false),
+	("01234567xxxx", "01234567", true),
+	("xx01234567xx", "01234567", true),
+	("xxxx01234567", "01234567", true),
+	("1234567xxxxx", "01234567", false),
+	("xxxxx0123456", "01234567", false),
 			// 9-15-byte needle
 			("xxxxxxxxxxxxx", "012345678", false),
-			("012345678xxxx", "012345678", true),
-			("xx012345678xx", "012345678", true),
-			("xxxx012345678", "012345678", true),
-			("12345678xxxxx", "012345678", false),
-			("xxxxx01234567", "012345678", false),
+	("012345678xxxx", "012345678", true),
+	("xx012345678xx", "012345678", true),
+	("xxxx012345678", "012345678", true),
+	("12345678xxxxx", "012345678", false),
+	("xxxxx01234567", "012345678", false),
 			// 16-byte needle
 			("xxxxxxxxxxxxxxxxxxxx", "0123456789ABCDEF", false),
-			("0123456789ABCDEFxxxx", "0123456789ABCDEF", true),
-			("xx0123456789ABCDEFxx", "0123456789ABCDEF", true),
-			("xxxx0123456789ABCDEF", "0123456789ABCDEF", true),
-			("123456789ABCDEFxxxxx", "0123456789ABCDEF", false),
-			("xxxxx0123456789ABCDE", "0123456789ABCDEF", false),
+	("0123456789ABCDEFxxxx", "0123456789ABCDEF", true),
+	("xx0123456789ABCDEFxx", "0123456789ABCDEF", true),
+	("xxxx0123456789ABCDEF", "0123456789ABCDEF", true),
+	("123456789ABCDEFxxxxx", "0123456789ABCDEF", false),
+	("xxxxx0123456789ABCDE", "0123456789ABCDEF", false),
 			// 17-31-byte needle
 			("xxxxxxxxxxxxxxxxxxxxx", "0123456789ABCDEFG", false),
-			("0123456789ABCDEFGxxxx", "0123456789ABCDEFG", true),
-			("xx0123456789ABCDEFGxx", "0123456789ABCDEFG", true),
-			("xxxx0123456789ABCDEFG", "0123456789ABCDEFG", true),
-			("123456789ABCDEFGxxxxx", "0123456789ABCDEFG", false),
-			("xxxxx0123456789ABCDEF", "0123456789ABCDEFG", false),
+	("0123456789ABCDEFGxxxx", "0123456789ABCDEFG", true),
+	("xx0123456789ABCDEFGxx", "0123456789ABCDEFG", true),
+	("xxxx0123456789ABCDEFG", "0123456789ABCDEFG", true),
+	("123456789ABCDEFGxxxxx", "0123456789ABCDEFG", false),
+	("xxxxx0123456789ABCDEF", "0123456789ABCDEFG", false),
 
 			// partial match cases
 			("xx01x", "012", false),                             // 3
@@ -210,18 +210,18 @@ namespace NStackTests {
 		(string, string, bool) [] containsAnyTests = {
 			// string, substring, expected
 			("", "", false),
-			("", "a", false),
-			("", "abc", false),
-			("a", "", false),
-			("a", "a", true),
-			("aaa", "a", true),
-			("abc", "xyz", false),
-			("abc", "xcz", true),
-			("a☺b☻c☹d", "uvw☻xyz", true),
-			("aRegExp*", ".(|)*+?^$[]", true),
-			("1....2....3....41....2....3....41....2....3....4", " ", false),
+	("", "a", false),
+	("", "abc", false),
+	("a", "", false),
+	("a", "a", true),
+	("aaa", "a", true),
+	("abc", "xyz", false),
+	("abc", "xcz", true),
+	("a☺b☻c☹d", "uvw☻xyz", true),
+	("aRegExp*", ".(|)*+?^$[]", true),
+	("1....2....3....41....2....3....41....2....3....4", " ", false),
 
-		};
+    };
 
 		[Test]
 		public void TestContainsAny ()
@@ -247,15 +247,15 @@ namespace NStackTests {
 		}
 
 		(string, uint, bool) [] containsRuneTests = {
-			("", 'a', false),
-			("a", 'a', true),
-			("aaa", 'a', true),
-			("abc", 'y', false),
-			("abc", 'c', true),
-			("a☺b☻c☹d", 'x', false),
-			("a☺b☻c☹d", '☻', true),
-			("aRegExp*", '*', true),
-		};
+	("", 'a', false),
+	("a", 'a', true),
+	("aaa", 'a', true),
+	("abc", 'y', false),
+	("abc", 'c', true),
+	("a☺b☻c☹d", 'x', false),
+	("a☺b☻c☹d", '☻', true),
+	("aRegExp*", '*', true),
+    };
 
 		[Test]
 		public void TestContainsRune ()
@@ -267,21 +267,21 @@ namespace NStackTests {
 		}
 
 		(string, string, bool) [] equalFoldsTest = {
-			("abc", "abc", true),
-			("ABcd", "ABcd", true),
-			("123abc", "123ABC", true),
-			("αβδ", "ΑΒΔ", true),
-			("abc", "xyz", false),
-			("abc", "XYZ", false),
-			("abcdefghijk", "abcdefghijX", false),
+	("abc", "abc", true),
+	("ABcd", "ABcd", true),
+	("123abc", "123ABC", true),
+	("αβδ", "ΑΒΔ", true),
+	("abc", "xyz", false),
+	("abc", "XYZ", false),
+	("abcdefghijk", "abcdefghijX", false),
 
 			// need byte array for these, as they are not 
 			("abcdefghijk", "abcdefghij\u212A", true),
-			("abcdefghijK", "abcdefghij\u212A", true),
-			("abcdefghijkz", "abcdefghij\u212Ay", false),
-			("abcdefghijKz", "abcdefghij\u212Ay", false),
+	("abcdefghijK", "abcdefghij\u212A", true),
+	("abcdefghijkz", "abcdefghij\u212Ay", false),
+	("abcdefghijKz", "abcdefghij\u212Ay", false),
 
-		};
+    };
 
 		[Test]
 		public void TestEqualFolds ()
@@ -296,17 +296,17 @@ namespace NStackTests {
 		}
 
 		(string, string, int) [] countTests = {
-			("", "", 1),
-			("", "notempty", 0),
-			("notempty", "", 9),
-			("smaller", "not smaller", 0),
-			("12345678987654321", "6", 2),
-			("611161116", "6", 3),
-			("notequal", "NotEqual", 0),
-			("equal", "equal", 1),
-			("abc1231231123q", "123", 3),
-			("11111", "11", 2)
-		};
+	("", "", 1),
+	("", "notempty", 0),
+	("notempty", "", 9),
+	("smaller", "not smaller", 0),
+	("12345678987654321", "6", 2),
+	("611161116", "6", 3),
+	("notequal", "NotEqual", 0),
+	("equal", "equal", 1),
+	("abc1231231123q", "123", 3),
+	("11111", "11", 2)
+    };
 
 		[Test]
 		public void TestCount ()
@@ -461,25 +461,25 @@ namespace NStackTests {
 		static (string, string, string, int, string) [] replaceTexts = {
 			// input, oldValue, newValue, n parameter, expected
 			("hello", "l", "L", 0, "hello"),
-			("hello", "l", "L", -1, "heLLo"),
-			("hello", "x", "X", -1, "hello"),
-			("", "x", "X", -1, ""),
-			("radar", "r", "<r>", -1, "<r>ada<r>"),
-			("", "", "<>", -1, "<>"),
-			("banana", "a", "<>", -1, "b<>n<>n<>"),
-			("banana", "a", "<>", 1, "b<>nana"),
-			("banana", "a", "<>", 1000, "b<>n<>n<>"),
-			("banana", "an", "<>", -1, "b<><>a"),
-			("banana", "ana", "<>", -1, "b<>na"),
-			("banana", "", "<>", -1, "<>b<>a<>n<>a<>n<>a<>"),
-			("banana", "", "<>", 10, "<>b<>a<>n<>a<>n<>a<>"),
-			("banana", "", "<>", 6, "<>b<>a<>n<>a<>n<>a"),
-			("banana", "", "<>", 5, "<>b<>a<>n<>a<>na"),
-			("banana", "", "<>", 1, "<>banana"),
-			("banana", "a", "a", -1, "banana"),
-			("banana", "a", "a", 1, "banana"),
-			("☺☻☹", "", "<>", -1, "<>☺<>☻<>☹<>")
-		};
+	("hello", "l", "L", -1, "heLLo"),
+	("hello", "x", "X", -1, "hello"),
+	("", "x", "X", -1, ""),
+	("radar", "r", "<r>", -1, "<r>ada<r>"),
+	("", "", "<>", -1, "<>"),
+	("banana", "a", "<>", -1, "b<>n<>n<>"),
+	("banana", "a", "<>", 1, "b<>nana"),
+	("banana", "a", "<>", 1000, "b<>n<>n<>"),
+	("banana", "an", "<>", -1, "b<><>a"),
+	("banana", "ana", "<>", -1, "b<>na"),
+	("banana", "", "<>", -1, "<>b<>a<>n<>a<>n<>a<>"),
+	("banana", "", "<>", 10, "<>b<>a<>n<>a<>n<>a<>"),
+	("banana", "", "<>", 6, "<>b<>a<>n<>a<>n<>a"),
+	("banana", "", "<>", 5, "<>b<>a<>n<>a<>na"),
+	("banana", "", "<>", 1, "<>banana"),
+	("banana", "a", "a", -1, "banana"),
+	("banana", "a", "a", 1, "banana"),
+	("☺☻☹", "", "<>", -1, "<>☺<>☻<>☹<>")
+    };
 
 		[Test]
 		public void TestReplace ()
@@ -495,80 +495,80 @@ namespace NStackTests {
 		(string, string, int) [] indexTests = {
 			// string, substring, expected index return
 			("", "", 0),
-			("", "a", -1),
-			("", "foo", -1),
-			("fo", "foo", -1),
-			("foo", "foo", 0),
-			("oofofoofooo", "f", 2),
-			("oofofoofooo", "foo", 4),
-			("barfoobarfoo", "foo", 3),
-			("foo", "", 0),
-			("foo", "o", 1),
-			("abcABCabc", "A", 3),
+	("", "a", -1),
+	("", "foo", -1),
+	("fo", "foo", -1),
+	("foo", "foo", 0),
+	("oofofoofooo", "f", 2),
+	("oofofoofooo", "foo", 4),
+	("barfoobarfoo", "foo", 3),
+	("foo", "", 0),
+	("foo", "o", 1),
+	("abcABCabc", "A", 3),
 			// cases with one byte strings - test special case in Index()
 			("", "a", -1),
-			("x", "a", -1),
-			("x", "x", 0),
-			("abc", "a", 0),
-			("abc", "b", 1),
-			("abc", "c", 2),
-			("abc", "x", -1),
+	("x", "a", -1),
+	("x", "x", 0),
+	("abc", "a", 0),
+	("abc", "b", 1),
+	("abc", "c", 2),
+	("abc", "x", -1),
 			// test special cases in Index() for short strings
 			("", "ab", -1),
-			("bc", "ab", -1),
-			("ab", "ab", 0),
-			("xab", "ab", 1),
-			("", "abc", -1),
-			("xbc", "abc", -1),
-			("abc", "abc", 0),
-			("xabc", "abc", 1),
-			("xabxc", "abc", -1),
-			("", "abcd", -1),
-			("xbcd", "abcd", -1),
-			("abcd", "abcd", 0),
-			("xabcd", "abcd", 1),
-			("xbcqq", "abcqq", -1),
-			("abcqq", "abcqq", 0),
-			("xabcqq", "abcqq", 1),
-			("xabxcqq", "abcqq", -1),
-			("xabcqxq", "abcqq", -1),
-			("", "01234567", -1),
-			("32145678", "01234567", -1),
-			("01234567", "01234567", 0),
-			("x01234567", "01234567", 1),
-			("x0123456x01234567", "01234567", 9),
-			("", "0123456789", -1),
-			("3214567844", "0123456789", -1),
-			("0123456789", "0123456789", 0),
-			("x0123456789", "0123456789", 1),
-			("x012345678x0123456789", "0123456789", 11),
-			("x01234567x89", "0123456789", -1),
-			("", "0123456789012345", -1),
-			("3214567889012345", "0123456789012345", -1),
-			("0123456789012345", "0123456789012345", 0),
-			("x0123456789012345", "0123456789012345", 1),
-			("x012345678901234x0123456789012345", "0123456789012345", 17),
-			("", "01234567890123456789", -1),
-			("32145678890123456789", "01234567890123456789", -1),
-			("01234567890123456789", "01234567890123456789", 0),
-			("x01234567890123456789", "01234567890123456789", 1),
-			("x0123456789012345678x01234567890123456789", "01234567890123456789", 21),
-			("", "0123456789012345678901234567890", -1),
-			("321456788901234567890123456789012345678911", "0123456789012345678901234567890", -1),
-			("0123456789012345678901234567890", "0123456789012345678901234567890", 0),
-			("x0123456789012345678901234567890", "0123456789012345678901234567890", 1),
-			("x012345678901234567890123456789x0123456789012345678901234567890", "0123456789012345678901234567890", 32),
-			("", "01234567890123456789012345678901", -1),
-			("32145678890123456789012345678901234567890211", "01234567890123456789012345678901", -1),
-			("01234567890123456789012345678901", "01234567890123456789012345678901", 0),
-			("x01234567890123456789012345678901", "01234567890123456789012345678901", 1),
-			("x0123456789012345678901234567890x01234567890123456789012345678901", "01234567890123456789012345678901", 33),
-			("xxxxxx012345678901234567890123456789012345678901234567890123456789012", "012345678901234567890123456789012345678901234567890123456789012", 6),
-			("", "0123456789012345678901234567890123456789", -1),
-			("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456789", 2),
-			("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456xxx", -1),
-			("xx0123456789012345678901234567890123456789012345678901234567890120123456789012345678901234567890123456xxx", "0123456789012345678901234567890123456xxx", 65)
-		};
+	("bc", "ab", -1),
+	("ab", "ab", 0),
+	("xab", "ab", 1),
+	("", "abc", -1),
+	("xbc", "abc", -1),
+	("abc", "abc", 0),
+	("xabc", "abc", 1),
+	("xabxc", "abc", -1),
+	("", "abcd", -1),
+	("xbcd", "abcd", -1),
+	("abcd", "abcd", 0),
+	("xabcd", "abcd", 1),
+	("xbcqq", "abcqq", -1),
+	("abcqq", "abcqq", 0),
+	("xabcqq", "abcqq", 1),
+	("xabxcqq", "abcqq", -1),
+	("xabcqxq", "abcqq", -1),
+	("", "01234567", -1),
+	("32145678", "01234567", -1),
+	("01234567", "01234567", 0),
+	("x01234567", "01234567", 1),
+	("x0123456x01234567", "01234567", 9),
+	("", "0123456789", -1),
+	("3214567844", "0123456789", -1),
+	("0123456789", "0123456789", 0),
+	("x0123456789", "0123456789", 1),
+	("x012345678x0123456789", "0123456789", 11),
+	("x01234567x89", "0123456789", -1),
+	("", "0123456789012345", -1),
+	("3214567889012345", "0123456789012345", -1),
+	("0123456789012345", "0123456789012345", 0),
+	("x0123456789012345", "0123456789012345", 1),
+	("x012345678901234x0123456789012345", "0123456789012345", 17),
+	("", "01234567890123456789", -1),
+	("32145678890123456789", "01234567890123456789", -1),
+	("01234567890123456789", "01234567890123456789", 0),
+	("x01234567890123456789", "01234567890123456789", 1),
+	("x0123456789012345678x01234567890123456789", "01234567890123456789", 21),
+	("", "0123456789012345678901234567890", -1),
+	("321456788901234567890123456789012345678911", "0123456789012345678901234567890", -1),
+	("0123456789012345678901234567890", "0123456789012345678901234567890", 0),
+	("x0123456789012345678901234567890", "0123456789012345678901234567890", 1),
+	("x012345678901234567890123456789x0123456789012345678901234567890", "0123456789012345678901234567890", 32),
+	("", "01234567890123456789012345678901", -1),
+	("32145678890123456789012345678901234567890211", "01234567890123456789012345678901", -1),
+	("01234567890123456789012345678901", "01234567890123456789012345678901", 0),
+	("x01234567890123456789012345678901", "01234567890123456789012345678901", 1),
+	("x0123456789012345678901234567890x01234567890123456789012345678901", "01234567890123456789012345678901", 33),
+	("xxxxxx012345678901234567890123456789012345678901234567890123456789012", "012345678901234567890123456789012345678901234567890123456789012", 6),
+	("", "0123456789012345678901234567890123456789", -1),
+	("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456789", 2),
+	("xx012345678901234567890123456789012345678901234567890123456789012", "0123456789012345678901234567890123456xxx", -1),
+	("xx0123456789012345678901234567890123456789012345678901234567890120123456789012345678901234567890123456xxx", "0123456789012345678901234567890123456xxx", 65)
+    };
 
 		[Test]
 		public void TestIndex ()
@@ -579,21 +579,21 @@ namespace NStackTests {
 		}
 
 		(string, string, int) [] lastIndexTests = {
-			("", "", 0),
-			("", "a", -1),
-			("", "foo", -1),
-			("fo", "foo", -1),
-			("foo", "foo", 0),
-			("foo", "f", 0),
-			("oofofoofooo", "f", 7),
-			("oofofoofooo", "foo", 7),
-			("barfoobarfoo", "foo", 9),
-			("foo", "", 3),
-			("foo", "o", 2),
-			("abcABCabc", "A", 3),
-			("abcABCabc", "a", 6),
+	("", "", 0),
+	("", "a", -1),
+	("", "foo", -1),
+	("fo", "foo", -1),
+	("foo", "foo", 0),
+	("foo", "f", 0),
+	("oofofoofooo", "f", 7),
+	("oofofoofooo", "foo", 7),
+	("barfoobarfoo", "foo", 9),
+	("foo", "", 3),
+	("foo", "o", 2),
+	("abcABCabc", "A", 3),
+	("abcABCabc", "a", 6),
 
-		};
+    };
 
 		[Test]
 		public void TestLastIndex ()
@@ -604,45 +604,45 @@ namespace NStackTests {
 		}
 
 		(string, string, int) [] indexAnyTests = {
-			("", "", -1),
-			("", "a", -1),
-			("", "abc", -1),
-			("a", "", -1),
-			("a", "a", 0),
-			("aaa", "a", 0),
-			("abc", "xyz", -1),
-			("abc", "xcz", 2),
-			("ab☺c", "x☺yz", 2),
-			("a☺b☻c☹d", "cx", ustring.Make ("a☺b☻").Length),
-			("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
-			("aRegExp*", ".(|)*+?^$[]", 7),
-			("1....2....3....41....2....3....41....2....3....4", " ", -1),
+	("", "", -1),
+	("", "a", -1),
+	("", "abc", -1),
+	("a", "", -1),
+	("a", "a", 0),
+	("aaa", "a", 0),
+	("abc", "xyz", -1),
+	("abc", "xcz", 2),
+	("ab☺c", "x☺yz", 2),
+	("a☺b☻c☹d", "cx", ustring.Make ("a☺b☻").Length),
+	("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
+	("aRegExp*", ".(|)*+?^$[]", 7),
+	("1....2....3....41....2....3....41....2....3....4", " ", -1),
 
 			// Need a byte initializer instead for Go [\xff][b] below
 			// ("012abcba210", "\xffb", 4),
 			//("012\x80bcb\x80210", "\xffb", 3)			
 		}, lastIndexAnyTests = {
-			("abc", "xyz", -1),
-			("a", "a", 0),
-			("", "", -1),
-			("", "a", -1),
-			("", "abc", -1),
-			("a", "", -1),
-			("aaa", "a", 2),
-			("abc", "ab", 1),
-			("ab☺c", "x☺yz", 2),
-			("a☺b☻c☹d", "cx", ustring.Make("a☺b☻").Length),
-			("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
-			("a.RegExp*", ".(|)*+?^$[]", 8),
-			("1....2....3....41....2....3....41....2....3....4", " ", -1),
+	("abc", "xyz", -1),
+	("a", "a", 0),
+	("", "", -1),
+	("", "a", -1),
+	("", "abc", -1),
+	("a", "", -1),
+	("aaa", "a", 2),
+	("abc", "ab", 1),
+	("ab☺c", "x☺yz", 2),
+	("a☺b☻c☹d", "cx", ustring.Make("a☺b☻").Length),
+	("a☺b☻c☹d", "uvw☻xyz", ustring.Make("a☺b").Length),
+	("a.RegExp*", ".(|)*+?^$[]", 8),
+	("1....2....3....41....2....3....41....2....3....4", " ", -1),
 			// Need a byte initializer instead for Go [\xff][b] below
 			//("012abcba210", "\xffb", 6),
 			//("012\x80bcb\x80210", "\xffb", 7)
 		}, lastIndexByteTests = {
-			("abcdefabcdef", "a", ustring.Make("abcdef").Length),      // something in the middle
+	("abcdefabcdef", "a", ustring.Make("abcdef").Length),      // something in the middle
 			("", "q", -1),
-			("abcdef", "q", -1),
-			("abcdefabcdef", "f", ustring.Make("abcdefabcde").Length), // last byte
+	("abcdef", "q", -1),
+	("abcdefabcdef", "f", ustring.Make("abcdefabcde").Length), // last byte
 			("zabcdefabcdef", "z", 0),                 // first byte
 			("a☺b☻c☹d", "b", ustring.Make("a☺").Length),               // non-ascii
 		};
@@ -675,17 +675,17 @@ namespace NStackTests {
 		public void TestIndexRune ()
 		{
 			(string, uint, int) [] testFirst = {
-				("", 'a', -1),
-				("", '☺', -1),
-				("foo", '☹', -1),
-				("foo", 'o', 1),
-				("foo☺bar", '☺', 3),
-				("foo☺☻☹bar", '☹', 9),
-				("a A x", 'A', 2),
-				("some_text=some_value", '=', 9),
-				("☺a", 'a', 3),
-				("a☻☺b", '☺', 4),
-			};
+	("", 'a', -1),
+	("", '☺', -1),
+	("foo", '☹', -1),
+	("foo", 'o', 1),
+	("foo☺bar", '☺', 3),
+	("foo☺☻☹bar", '☹', 9),
+	("a A x", 'A', 2),
+	("some_text=some_value", '=', 9),
+	("☺a", 'a', 3),
+	("a☻☺b", '☺', 4),
+	};
 			foreach ((string str, uint rune, int expected) in testFirst) {
 				var ustr = ustring.Make (str);
 				Assert.AreEqual (expected, ustr.IndexOf (rune));
@@ -716,61 +716,100 @@ namespace NStackTests {
 		}
 
 		[Test]
-		public void TestConsoleWidth()
+		public void TestConsoleWidth ()
 		{
-			var sc = new Rune(0xd83d);
-			var r = new Rune(0xdd2e);
-			Assert.AreEqual(1, Rune.ColumnWidth(sc));
-			Assert.False(Rune.IsNonSpacingChar(r));
-			Assert.AreEqual(1, Rune.ColumnWidth(r));
-			var fr = new Rune(sc, r);
-			Assert.False(Rune.IsNonSpacingChar(fr));
-			Assert.AreEqual(1, Rune.ColumnWidth(fr));
-			var us = ustring.Make(fr);
-			Assert.AreEqual(1, us.ConsoleWidth);
+			var sc = new Rune (0xd83d);
+			var r = new Rune (0xdd2e);
+			Assert.AreEqual (1, Rune.ColumnWidth (sc));
+			Assert.False (Rune.IsNonSpacingChar (r));
+			Assert.AreEqual (1, Rune.ColumnWidth (r));
+			var fr = new Rune (sc, r);
+			Assert.False (Rune.IsNonSpacingChar (fr));
+			Assert.AreEqual (1, Rune.ColumnWidth (fr));
+			var us = ustring.Make (fr);
+			Assert.AreEqual (1, us.ConsoleWidth);
 		}
 
 		[Test]
-		public void Test_Substring()
-		{
-			ustring us = "This a test to return a substring";
-			Assert.AreEqual("test to return a substring", us.Substring(7));
-			Assert.AreEqual("test to return", us.Substring(7, 14));
-		}
-
-		[Test]
-		public void Test_RuneSubstring()
+		public void Test_Substring ()
 		{
 			ustring us = "This a test to return a substring";
-			Assert.AreEqual("test to return a substring", us.RuneSubstring(7));
-			Assert.AreEqual("test to return", us.RuneSubstring(7, 14));
+			Assert.AreEqual ("test to return a substring", us.Substring (7));
+			Assert.AreEqual ("test to return", us.Substring (7, 14));
 		}
 
 		[Test]
-		public void Test_ToRunes()
+		public void Test_RuneSubstring ()
+		{
+			ustring us = "This a test to return a substring";
+			Assert.AreEqual ("test to return a substring", us.RuneSubstring (7));
+			Assert.AreEqual ("test to return", us.RuneSubstring (7, 14));
+		}
+
+		[Test]
+		public void Test_ToRunes ()
 		{
 			ustring us = "Some long text that 🤖🧠 is super cool";
-			uint[] runesArray = us.ToRunes();
-			Assert.AreEqual(us, runesArray);
+			uint [] runesArray = us.ToRunes ();
+			Assert.AreEqual (us, runesArray);
 		}
 
 		[Test]
-		public void Make_Environment_NewLine()
+		public void Make_Environment_NewLine ()
 		{
-			var us = ustring.Make(Environment.NewLine);
-			if (Environment.NewLine.Length == 1)
-			{
-				Assert.AreEqual('\n', us[0]);
-				Assert.AreEqual(10, us[0]);
-			}
-			else
-			{
-				Assert.AreEqual('\r', us[0]);
-				Assert.AreEqual(13, us[0]);
+			var us = ustring.Make (Environment.NewLine);
+			if (Environment.NewLine.Length == 1) {
+				Assert.AreEqual ('\n', us [0]);
+				Assert.AreEqual (10, us [0]);
+			} else {
+				Assert.AreEqual ('\r', us [0]);
+				Assert.AreEqual (13, us [0]);
 
-				Assert.AreEqual('\n', us[1]);
-				Assert.AreEqual(10, us[1]);
+				Assert.AreEqual ('\n', us [1]);
+				Assert.AreEqual (10, us [1]);
 			}
+		}
+
+		[Test]
+		public void Substring_Same_As_String_Substring ()
+		{
+			ustring text = "Check this out 你";
+			var str = text.ToString ();
+			str = str?.Substring (0, Math.Min (17, str.Length));
+			var ustr = text.Substring (0, text.Length);
+			Assert.AreEqual (str, ustr);
+		}
+
+		[Test]
+		public void IsNullOrEmpty_Accept_Null_String_Arg ()
+		{
+			string? str = null;
+			Assert.True (string.IsNullOrEmpty (str));
+			Assert.True (ustring.IsNullOrEmpty (str));
+
+			str = "";
+			Assert.True (string.IsNullOrEmpty (str));
+			Assert.True (ustring.IsNullOrEmpty (str));
+
+			str = " ";
+			Assert.False (string.IsNullOrEmpty (str));
+			Assert.False (ustring.IsNullOrEmpty (str));
+		}
+
+		[Test]
+		public void IsNullOrEmpty_Accept_Null_Ustring_Arg ()
+		{
+			ustring? ustr = null;
+			Assert.True (string.IsNullOrEmpty ((string)ustr));
+			Assert.True (ustring.IsNullOrEmpty (ustr));
+
+			ustr = "";
+			Assert.True (string.IsNullOrEmpty (ustr.ToString ()));
+			Assert.True (ustring.IsNullOrEmpty (ustr));
+
+			ustr = " ";
+			Assert.False (string.IsNullOrEmpty (ustr.ToString ()));
+			Assert.False (ustring.IsNullOrEmpty (ustr));
 		}
 	}
 }


### PR DESCRIPTION
`ustring.IsNullOrEmpty` method now accept a null argument. A `string` type can now be cast to `ustring` type.
I also changed the `.editorconfig` file to be consistent on all changes.