### PR TITLE
Fixes #79. Needed to add unit test for equal and not equal operators.

### DIFF
--- a/NStack/strings/ustring.cs
+++ b/NStack/strings/ustring.cs
@@ -2230,9 +2230,7 @@ namespace NStack {
 		/// <returns></returns>
 		public static bool IsNullOrEmpty (ustring value)
 		{
-			if (value == null)
-				return true;
-			if (value.Length == 0)
+			if (value?.IsEmpty != false)
 				return true;
 			return false;
 		}

--- a/NStackTests/ustringTest.cs
+++ b/NStackTests/ustringTest.cs
@@ -821,5 +821,71 @@ namespace NStackTests {
 			Assert.False (string.IsNullOrEmpty (ustr.ToString ()));
 			Assert.False (ustring.IsNullOrEmpty (ustr));
 		}
+
+		[Test]
+		public void Operator_Equal_Ustring_Versus_String ()
+		{
+			ustring? ustr = null;
+			string? str = null;
+			Assert.True (ustr == str);
+			Assert.True (str == ustr);
+			Assert.True (ustr == null);
+			Assert.True (str == null);
+			Assert.False (ustr == "");
+			Assert.False (str == "");
+
+			ustr = "";
+			str = "";
+			Assert.True (ustr == str);
+			Assert.True (str == ustr);
+			Assert.False (ustr == null);
+			Assert.False (str == null);
+			Assert.True (ustr == "");
+			Assert.True (str == "");
+
+			ustr = " ";
+			str = " ";
+			Assert.True (ustr == str);
+			Assert.True (str == ustr);
+			Assert.False (ustr == null);
+			Assert.False (str == null);
+			Assert.False (ustr == "");
+			Assert.False (str == "");
+			Assert.True (ustr == " ");
+			Assert.True (str == " ");
+		}
+
+		[Test]
+		public void Operator_Not_Equal_Ustring_Versus_String ()
+		{
+			ustring? ustr = null;
+			string? str = null;
+			Assert.False (ustr != str);
+			Assert.False (str != ustr);
+			Assert.False (ustr != null);
+			Assert.False (str != null);
+			Assert.True (ustr != "");
+			Assert.True (str != "");
+
+			ustr = "";
+			str = "";
+			Assert.False (ustr != str);
+			Assert.False (str != ustr);
+			Assert.True (ustr != null);
+			Assert.True (str != null);
+			Assert.False (ustr != "");
+			Assert.False (str != "");
+
+			ustr = " ";
+			str = " ";
+			Assert.False (ustr != str);
+			Assert.False (str != ustr);
+			Assert.True (ustr != null);
+			Assert.True (str != null);
+			Assert.True (ustr != "");
+			Assert.True (str != "");
+			Assert.False (ustr != " ");
+			Assert.False (str != " ");
+		}
 	}
 }


### PR DESCRIPTION
To be sure that the `ustring` type acts the same as `string` type.